### PR TITLE
Use more canonical environment variables

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func NewClient(endpoint string, token string) *Client {
 // NewClientFromEnv creates a new instance of a NexusClient from environment
 // variables
 func NewClientFromEnv() (*Client, error) {
-	endpoint := os.Getenv("NEXUS_ENDPOINT")
+	endpoint := os.Getenv("NEXUS_SERVER")
 	token := os.Getenv("NEXUS_APIKEY")
 
 	if utf8.RuneCountInString(endpoint) < 1 || utf8.RuneCountInString(endpoint) < 1 {

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func Test_NewClientFromEnv(t *testing.T) {
 
 	assert.NotNil(t, err)
 
-	os.Setenv("NEXUS_ENDPOINT", endpoint)
+	os.Setenv("NEXUS_SERVER", endpoint)
 	os.Setenv("NEXUS_APIKEY", token)
 
 	client, err2 := NewClientFromEnv()


### PR DESCRIPTION
`NEXUS_ENDPOINT` ≈ `NEXUS_SERVER` for most of slabs' stuff ;)
